### PR TITLE
Fix misplaced parenthesis for `taxClasses.find`

### DIFF
--- a/src/lib/taxcalc.js
+++ b/src/lib/taxcalc.js
@@ -156,15 +156,16 @@ export function updateProductPrices ({ product, rate, sourcePriceInclTax = false
 
 export function calculateProductTax ({ product, taxClasses, taxCountry = 'PL', taxRegion = '', sourcePriceInclTax = false, deprecatedPriceFieldsSupport = false, finalPriceInclTax = true, userGroupId = null, isTaxWithUserGroupIsActive }) {
   let rateFound = false
-  if (product.tax_class_id > 0) {
+  let product_tax_class_id = parseInt(product.tax_class_id)
+  if (product_tax_class_id > 0) {
     let taxClass
     if (isTaxWithUserGroupIsActive) {
       taxClass = taxClasses.find((el) =>
-        el.product_tax_class_ids.indexOf(parseInt(product.tax_class_id)) >= 0 &&
+        el.product_tax_class_ids.indexOf(product_tax_class_id) >= 0 &&
           el.customer_tax_class_ids.indexOf(userGroupId) >= 0
       )
     } else {
-      taxClass = taxClasses.find((el) => el.product_tax_class_ids.indexOf(parseInt(product.tax_class_id) >= 0))
+      taxClass = taxClasses.find((el) => el.product_tax_class_ids.indexOf(product_tax_class_id) >= 0)
     }
 
     if (taxClass) {


### PR DESCRIPTION
(and also avoid a ParseInt call for each item tested)

See DivanteLtd/vue-storefront#4056 for the same fix in vue-storefront 