### PR TITLE
Update to `storefront-query-builder` version `1.0.0`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add url module - @gibkigonzo (#3942)
 - Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)
 - moved server logic into packages/core @resubaka (#47)
+- Update to `storefront-query-builder` version `1.0.0` - @cewald (#51)
 
 ### Changed / Improved
 

--- a/config/default.json
+++ b/config/default.json
@@ -235,6 +235,7 @@
     "defaultCatalog": {
       "registeredExtensions": [
         "example-processor",
+        "example-custom-filter",
         "elastic-stock"
       ]
     },
@@ -280,6 +281,9 @@
       "resultProcessors": {
         "product": "my-product-processor"
       }
+    },
+    "example-custom-filter": {
+      "catalogFilter": [ "SampleFilter" ]
     }
   },
   "magento2": {

--- a/package.json
+++ b/package.json
@@ -73,7 +73,7 @@
     "@storefront-api/core": "1.0.0-rc2",
     "ajv": "^6.4.0",
     "ajv-keywords": "^3.4.0",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "cli-color": "^2.0.0",
     "commander": "^2.19.0",
     "compression": "^1.7.2",
@@ -115,7 +115,7 @@
     "typescript": "3.7.*",
     "vuepress": "^1.2.0",
     "winston": "^3.2.0",
-    "storefront-query-builder": "^0.0.9"
+    "storefront-query-builder": "^1.0.0"
   },
   "devDependencies": {
     "@types/cli-color": "^0.3.30",

--- a/packages/default-catalog/api/catalog.ts
+++ b/packages/default-catalog/api/catalog.ts
@@ -7,6 +7,7 @@ import { sha3_224 } from 'js-sha3'
 import Logger from '@storefront-api/lib/logger'
 import bodybuilder from 'bodybuilder'
 import { elasticsearch, SearchQuery } from 'storefront-query-builder'
+import loadCustomFilters from '../helper/loadCustomFilters'
 
 function _cacheStorageHandler (config, result, hash, tags) {
   if (config.server.useOutputCache && cache) {
@@ -54,7 +55,8 @@ export default ({config, db}) => async function (req, res, body) {
   }
 
   if (req.query.request_format === 'search-query') { // search query and not Elastic DSL - we need to translate it
-    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody) })
+    const customFilters = await loadCustomFilters(config)
+    requestBody = await elasticsearch.buildQueryBodyFromSearchQuery({ config, queryChain: bodybuilder(), searchQuery: new SearchQuery(requestBody), customFilters })
   }
   if (req.query.response_format) responseFormat = req.query.response_format
 

--- a/packages/default-catalog/api/extensions/example-custom-filter/filter/catalog/SampleFilter.ts
+++ b/packages/default-catalog/api/extensions/example-custom-filter/filter/catalog/SampleFilter.ts
@@ -1,0 +1,13 @@
+import { FilterInterface } from 'storefront-query-builder'
+
+const filter: FilterInterface = {
+  priority: 1,
+  check: ({ operator, value, attribute, queryChain }) => attribute === 'custom-filter-name',
+  filter ({ value, attribute, operator, queryChain }) {
+    // Do you custom filter logic like: queryChain.filter('terms', attribute, value)
+    return queryChain
+  },
+  mutator: (value) => typeof value !== 'object' ? { 'in': [value] } : value
+}
+
+export default filter

--- a/packages/default-catalog/api/extensions/example-custom-filter/index.ts
+++ b/packages/default-catalog/api/extensions/example-custom-filter/index.ts
@@ -1,0 +1,7 @@
+import { Router } from 'express'
+
+module.exports = () => {
+  let exampleFilter = Router()
+
+  return exampleFilter
+}

--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -1,0 +1,27 @@
+import path from 'path'
+
+export default async function loadModuleCustomFilters (config: Record<string, any>, type: string = 'catalog'): Promise<any> {
+  let filters: any = {}
+  let filterPromises: Promise<any>[] = []
+
+  for (const mod of config.modules.defaultCatalog.registeredExtensions) {
+    if (config.extensions.hasOwnProperty(mod) && config.extensions[mod].hasOwnProperty(type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
+      const moduleFilter = config.extensions[mod][type + 'Filter']
+      const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
+      for (const filterName of moduleFilter) {
+        const filePath = path.resolve(...dirPath, filterName + '.ts')
+        filterPromises.push(
+          import(filePath)
+            .then(module => {
+              filters[filterName] = module.default
+            })
+            .catch(e => {
+              console.log(e)
+            })
+        )
+      }
+    }
+  }
+
+  return Promise.all(filterPromises).then((e) => filters)
+}

--- a/packages/default-catalog/package.json
+++ b/packages/default-catalog/package.json
@@ -26,7 +26,7 @@
   "author": "Piotr Karwatka <pkarwatka@divante.pl>",
   "dependencies": {
     "@storefront-api/lib": "1.0.0-rc2",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "storefront-query-builder": "^0.0.9",
     "config": "^1.30.0",
     "graphql": "^14.5.8",

--- a/packages/default-img/package.json
+++ b/packages/default-img/package.json
@@ -24,7 +24,7 @@
   "author": "Piotr Karwatka <pkarwatka@divante.pl>",
   "dependencies": {
     "@storefront-api/lib": "1.0.0-rc2",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "config": "^1.30.0",
     "graphql": "^14.5.8",
     "js-sha3": "^0.8.0",

--- a/packages/default-vsf/package.json
+++ b/packages/default-vsf/package.json
@@ -27,7 +27,7 @@
     "@storefront-api/lib": "1.0.0-rc2",
     "@storefront-api/platform": "1.0.0-rc2",
     "resource-router-middleware": "^0.6.0",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "jwa": "^1.1.5",
     "config": "^1.30.0",
     "kue": "^0.11.6",

--- a/packages/platform-magento1/package.json
+++ b/packages/platform-magento1/package.json
@@ -26,7 +26,7 @@
     "magento1-vsbridge-client": "github:DivanteLtd/magento1-vsbridge-client",
     "@storefront-api/lib": "1.0.0-rc2",
     "@storefront-api/platform-abstract": "1.0.0-rc2",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "config": "^1.30.0",
     "typescript": "3.7.*"
   },

--- a/packages/platform-magento2/package.json
+++ b/packages/platform-magento2/package.json
@@ -25,7 +25,7 @@
   "dependencies": {
     "@storefront-api/lib": "1.0.0-rc2",
     "@storefront-api/platform-abstract": "1.0.0-rc2",
-    "bodybuilder": "2.2.13",
+    "bodybuilder": "^2.2.21",
     "config": "^1.30.0",
     "typescript": "3.7.*",
     "magento2-rest-client": "github:DivanteLtd/magento2-rest-client"

--- a/yarn.lock
+++ b/yarn.lock
@@ -2882,12 +2882,12 @@ body-parser@1.19.0, body-parser@^1.12.2, body-parser@^1.17.1, body-parser@^1.18.
     raw-body "2.4.0"
     type-is "~1.6.17"
 
-bodybuilder@2.2.13:
-  version "2.2.13"
-  resolved "https://registry.yarnpkg.com/bodybuilder/-/bodybuilder-2.2.13.tgz#82ced1c2144bd9ddce97c5d89fa13f7e24c40f8e"
-  integrity sha512-U34iuuZCLa7xE/BSJ1i/F+P2uwOAG76CQ47jES/N1PSQM2dSoCWxXZ4Pq/B2i0othEI/o7kVKLu+3QOFFkjcMg==
+bodybuilder@2.2.21:
+  version "2.2.21"
+  resolved "https://registry.yarnpkg.com/bodybuilder/-/bodybuilder-2.2.21.tgz#1a7a5d31189cf10a6fbd87668ac8aa386ac8cc38"
+  integrity sha512-Ys0Cas7ri7dcv3f62HwB2Lclk2oBCv86pakuEs4liK6hhL9ikTEairZ700k4VHD7vgvr2CW2Kogh4E5Ivmkg2A==
   dependencies:
-    lodash "^4.9.0"
+    lodash "^4.17.11"
 
 bonjour@^3.5.0:
   version "3.5.0"
@@ -8494,7 +8494,7 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.9.0:
+lodash@4.17.15, lodash@^4.0.0, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.12, lodash@^4.17.13, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.3, lodash@^4.17.4, lodash@^4.17.5:
   version "4.17.15"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.15.tgz#b447f6670a0455bbfeedd11392eff330ea097548"
   integrity sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==


### PR DESCRIPTION
### Related Issues
<!--  Put related issue number which this PR is closing. For example #123 -->

Update to `storefront-query-builder` version `1.0.0`

This is connected to the update of `storefront-query-builder` to support new features as extendable filters and more customizable sorting.

Read more about here: https://github.com/DivanteLtd/storefront-query-builder/pull/6

---

* Update the Unit-Tests to accept the SearchQuery object
* Update to `storefront-query-builder` version `1.0.0`
* Update Docs – add a recipe on how to add a custom filters

### Short Description and Why It's Useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This is useful to allow a more flexible way to add or rewrite custom filters without need to fork and edit the `storefront-query-builder` repository. There is also a more complex sorting added.

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)