### PR TITLE
Don't import custom-filter class using file ending

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,7 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Add url module - @gibkigonzo (#3942)
 - Add fallback for `sourcePriceInclTax` and `finalPriceInclTax` in `magento1` platform - @cewald (#398)
 - moved server logic into packages/core @resubaka (#47)
-- Update to `storefront-query-builder` version `1.0.0` - @cewald (#51)
+- Update to `storefront-query-builder` version `1.0.0` - @cewald (#51, #52, #53)
 
 ### Changed / Improved
 

--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -9,7 +9,7 @@ export default async function loadModuleCustomFilters (config: Record<string, an
       const moduleFilter = config.extensions[mod][type + 'Filter']
       const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
       for (const filterName of moduleFilter) {
-        const filePath = path.resolve(...dirPath, filterName + '.ts')
+        const filePath = path.resolve(...dirPath, filterName)
         filterPromises.push(
           import(filePath)
             .then(module => {


### PR DESCRIPTION
### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

This leads to an exception in production-mode because the file couldn't be found after it's parsed into JS during the build.

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
