### PR TITLE
fix: changed root package.json back to private

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "storefront-api",
   "version": "1.0.0-rc.2",
-  "private": false,
+  "private": true,
   "description": "Storefront GraphQL API",
   "main": "dist",
   "engineStrict": true,


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

This is needed as in yarn workspaces the root package needs to be private. You can read more about it here https://classic.yarnpkg.com/en/docs/workspaces/#toc-how-to-use-it.

**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
