### PR TITLE
[WIP] fix error which came when trying to build docker image

### DIFF
--- a/docker/storefront-api/Dockerfile
+++ b/docker/storefront-api/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10-alpine
+FROM node:10-alpine3.11
 
 ENV VS_ENV prod
 
@@ -11,8 +11,8 @@ COPY yarn.lock ./
 
 RUN apk --no-cache --update upgrade musl
 RUN apk add --no-cache \
-			--repository http://dl-3.alpinelinux.org/alpine/edge/community \
-			--repository http://dl-3.alpinelinux.org/alpine/edge/main \
+			--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
+			--repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
 			--virtual .build-deps \
         python \
         make \


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
I have some errors when trying to build fresh docker image.

1. 
```
Error relocating /lib/libmount.so.1: secure_getenv: symbol not found
Error relocating /lib/libblkid.so.1: secure_getenv: symbol not found
ERROR: gdk-pixbuf-2.40.0-r2.trigger: script exited with error 127
```
According to this comment https://gitlab.alpinelinux.org/alpine/aports/issues/9947#note_42395 we need to use same alpine version repository as is used in docker image. `node:10-alpine` uses `v3.9` and we want to use newest version
```
			--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
			--repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
```
So we have mismatch. To fix that there are two ways: use node lts which is 12.16.2 and `node:12.16.2-alpine` already use `v3.11` or specify alpine version for node10 image which I did. https://github.com/DivanteLtd/storefront-api/commit/77db53a90af353a3aed625ae3a3d37c5bf3b3cf6

2. 
```
error Couldn't find any versions for "@storefront-api/core" that matches "1.0.0-rc2"
info Visit https://yarnpkg.com/en/docs/cli/install for documentation about this command.
```
We need to use semantic versioning for packages. https://stackoverflow.com/a/16888025/6722573 So we need to change `1.0.0-rc2` to `1.0.0-rc.2` https://semver.npmjs.com/

3.
```
Creating sfa_redis_1 ... 
Creating elasticsearch ... error

Creating sfa_redis_1   ... done
62110". You have to remove (or rename) that container to be able to reuse that name.

ERROR: for es7  Cannot create container for service es7: Conflict. The container name "/elasticsearch" is already in use by container "ca3203b26531bf209785f666688f36bf7d81fac97b54b1abc01d668738762110". You have to remove (or rename) that container to be able to reuse that name.
ERROR: Encountered errors while bringing up the project.
```
That is probably because I have already container with same name (vsf-api), so I've added/changed names for containers to be uniq for this docker-compose.

4.
```
app_1    | Something went wrong installing the "sharp" module
app_1    | 
app_1    | Error loading shared library libvips-cpp.so.42: No such file or directory (needed by /var/www/node_modules/sharp/build/Release/sharp.node)
app_1    | 
app_1    | - Remove the "node_modules/sharp" directory, run "npm install" and look for errors
app_1    | - Consult the installation documentation at https://sharp.pixelplumbing.com/en/stable/install/
app_1    | - Search for this error at https://github.com/lovell/sharp/issues
app_1    | 
app_1    | [nodemon] app crashed - waiting for file changes before starting...

```
This is probably last error that needs to be fixed, I'm still working on it.



**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
