### PR TITLE
add missing argument for catchInvalidRequests

### DIFF
--- a/packages/lib/error.ts
+++ b/packages/lib/error.ts
@@ -1,6 +1,6 @@
 import config from 'config'
 
-export function catchInvalidRequests (err, req, res) {
+export function catchInvalidRequests (err, req, res, next) {
   const { statusCode, message = '', stack = '' } = err;
   const stackTrace = stack
     .split(/\r?\n/)


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
In https://github.com/DivanteLtd/storefront-api/pull/59 I didn't add last argument `next` which wasn't used, but it is requires because if we have 3 will not get error as first argument.
`app.use((err, req, res, next))`
`app.use((req, res,next))`


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [x] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
