### PR TITLE
Error with winston

### DIFF
--- a/packages/default-vsf/worker/log.ts
+++ b/packages/default-vsf/worker/log.ts
@@ -1,19 +1,17 @@
 import winston from 'winston'
 
-winston['emitErrs'] = true;
-
 if (!global['logger']) {
-  // @ts-ignore
-  global['logger'] = new winston.Logger({
+  global['logger'] = winston.createLogger({
     transports: [
       new winston.transports.Console({
         level: 'info',
-        handleExceptions: false,
-        // @ts-ignore
-        json: false,
-        prettyPrint: true,
-        colorize: true,
-        timestamp: true
+        format: winston.format.combine(
+          winston.format.colorize(),
+          winston.format.json(),
+          winston.format.timestamp(),
+          winston.format.prettyPrint()
+        ),
+        handleExceptions: false
       })
     ],
     exitOnError: false


### PR DESCRIPTION
Hi @pkarw,

When you run the yarn o2m command there is an error with winston. 

Version 3.2 is used and since version 3.0 they removed `logger.emitErrs = false;` ( https://github.com/winstonjs/winston/issues/1200#issuecomment-362183316 )

They also changed the way to instantiate the logger and format I updated the code to be compatible with version 3.2.

### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->

closes #

### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->



### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
