### PR TITLE
fix: Reduce the number of layers in the storefront-api Dockerfile.

### DIFF
--- a/docker/storefront-api/Dockerfile
+++ b/docker/storefront-api/Dockerfile
@@ -4,16 +4,15 @@ ENV VS_ENV prod
 
 WORKDIR /var/www
 
-RUN apk add --no-cache curl git python make g++
+COPY package.json yarn.lock ./
 
-COPY package.json ./
-COPY yarn.lock ./
-
-RUN apk --no-cache --update upgrade musl
-RUN apk add --no-cache \
+RUN apk --no-cache --update upgrade musl \
+    && apk add --no-cache \
 			--repository http://dl-cdn.alpinelinux.org/alpine/edge/community \
 			--repository http://dl-cdn.alpinelinux.org/alpine/edge/main \
 			--virtual .build-deps \
+        curl \
+        git \
         python \
         make \
         g++ \


### PR DESCRIPTION
Taking into account the official docker documentation and best practices the number of Dockerfile layers for storefront-api with node.js is reduced.

Reference information:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers

### Related issues
<!--  Put related issue number this PR is closing. For example #123 -->


### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->
Taking into account the official docker documentation and best practices the number of Dockerfile layers for storefront-api with node.js is reduced.

Reference information:
https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#minimize-the-number-of-layers


### Screenshots of visual changes before/after (if there are any)
<!-- if you made any changes in the UI, please provide before/after screenshots -->


**IMPORTANT NOTICE** - Remember to update `CHANGELOG.md` with a description of your change

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [X] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
