### PR TITLE
Bugfix for wrong config path in `loadCustomFilters`

### DIFF
--- a/packages/default-catalog/helper/loadCustomFilters.ts
+++ b/packages/default-catalog/helper/loadCustomFilters.ts
@@ -5,7 +5,7 @@ export default async function loadModuleCustomFilters (config: Record<string, an
   const filterPromises: Promise<any>[] = []
 
   for (const mod of config.modules.defaultCatalog.registeredExtensions) {
-    if (Object.prototype.hasOwnProperty.call(config.extensions, mod) && Object.prototype.hasOwnProperty.call(config.extensions, type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
+    if (Object.prototype.hasOwnProperty.call(config.extensions, mod) && Object.prototype.hasOwnProperty.call(config.extensions[mod], type + 'Filter') && Array.isArray(config.extensions[mod][type + 'Filter'])) {
       const moduleFilter = config.extensions[mod][type + 'Filter']
       const dirPath = [__dirname, '../api/extensions/' + mod + '/filter/', type]
       for (const filterName of moduleFilter) {
@@ -23,5 +23,5 @@ export default async function loadModuleCustomFilters (config: Record<string, an
     }
   }
 
-  return Promise.all(filterPromises).then((e) => filters)
+  return Promise.all(filterPromises).then(() => filters)
 }


### PR DESCRIPTION
### Short description and why it's useful
<!-- describe in a few words what is this Pull Request changing and why it's useful -->

The if-clause in line 8 will always return `false` for the second statement as the path to the extensions configs isn't correct.

### Contribution and currently important rules acceptance
<!-- Please get familiar with following info -->

- [ ] I read and followed [contribution rules](https://github.com/DivanteLtd/storefront-api/blob/develop/CONTRIBUTING.md)
